### PR TITLE
Remove C++ compiler dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(libxeddsa VERSION 2.0.0)
+project(libxeddsa VERSION 2.0.0 LANGUAGES C)
 
 include(CTest)
 

--- a/ref10/CMakeLists.txt
+++ b/ref10/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(ref10)
+project(ref10 LANGUAGES C)
 
 include(CTest)
 


### PR DESCRIPTION
Specify project language in CMake to remove implicit dependency on C++ compiler.